### PR TITLE
Allow doctrine/annotations:^2.0 package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "doctrine/orm": "^2.4",
     "pagerfanta/pagerfanta": "^1.0",
     "symfony/options-resolver": "^2.7|^3.0|^4.0|^5.4|^6.0",
-    "doctrine/annotations": "^1.13"
+    "doctrine/annotations": "^1.13|^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
allow doctrine annotations:^2.0 as it is required by friendsofphp/php-cs-fixer:^3.22